### PR TITLE
sync(bills): add 4 CLI commands from docs

### DIFF
--- a/cmd/bills/bills.go
+++ b/cmd/bills/bills.go
@@ -1,0 +1,32 @@
+package bills
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const basePath = "/v1/bills"
+
+// Cmd is the root bills command registered by the parent cmd package.
+var Cmd = &cobra.Command{
+	Use:   "bills",
+	Short: "Manage bills (Razorpay Billme)",
+}
+
+// parseJSONFlag reads a string flag and parses its value as JSON.
+// Empty values return (nil, nil) so callers can omit the field from the body.
+// Used for nested object/array body params (customer, line_items, etc.) where
+// the doc surface is too deep to expose as flat flags.
+func parseJSONFlag(cmd *cobra.Command, name string) (interface{}, error) {
+	raw, _ := cmd.Flags().GetString(name)
+	if raw == "" {
+		return nil, nil
+	}
+	var v interface{}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return nil, fmt.Errorf("--%s: invalid JSON: %w", name, err)
+	}
+	return v, nil
+}

--- a/cmd/bills/create.go
+++ b/cmd/bills/create.go
@@ -1,0 +1,160 @@
+package bills
+
+import (
+	"fmt"
+
+	"github.com/razorpay/razorpay-cli/api"
+	"github.com/razorpay/razorpay-cli/cmd/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a bill (Billme receipt)",
+	Long: `Create a Razorpay Billme receipt.
+
+Scalar fields are passed as typed flags. Nested object and array-of-object
+fields (customer, employee, loyalty, line_items, receipt_summary, taxes,
+payments, event, irn) are passed as JSON strings.
+
+Example:
+  razorpay bills create \
+    --business-type retail \
+    --business-category food_and_beverages \
+    --receipt-timestamp 1700000000 \
+    --receipt-number INV-001 \
+    --receipt-type tax_invoice \
+    --receipt-delivery digital \
+    --receipt-summary '{"total":10000,"tax":1800,"payment_status":"paid"}' \
+    --payments '[{"method":"card","currency":"INR","amount":10000}]' \
+    --customer '{"name":"Alice","email":"alice@example.com"}' \
+    --line-items '[{"sku":"X","quantity":1,"price":10000}]'`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		businessType, _ := cmd.Flags().GetString("business-type")
+		businessCategory, _ := cmd.Flags().GetString("business-category")
+		receiptTimestamp, _ := cmd.Flags().GetInt64("receipt-timestamp")
+		receiptNumber, _ := cmd.Flags().GetString("receipt-number")
+		receiptType, _ := cmd.Flags().GetString("receipt-type")
+		receiptDelivery, _ := cmd.Flags().GetString("receipt-delivery")
+
+		if receiptTimestamp <= 0 {
+			return fmt.Errorf("--receipt-timestamp is required and must be > 0")
+		}
+
+		body := map[string]interface{}{
+			"business_type":     businessType,
+			"business_category": businessCategory,
+			"receipt_timestamp": receiptTimestamp,
+			"receipt_number":    receiptNumber,
+			"receipt_type":      receiptType,
+			"receipt_delivery":  receiptDelivery,
+		}
+
+		// Optional scalar fields.
+		optionalStrings := []struct{ flag, key string }{
+			{"store-code", "store_code"},
+			{"bar-code-number", "bar_code_number"},
+			{"qr-code-number", "qr_code_number"},
+			{"billing-pos-number", "billing_pos_number"},
+			{"pos-category", "pos_category"},
+			{"order-number", "order_number"},
+			{"order-service-type", "order_service_type"},
+			{"delivery-status-url", "delivery_status_url"},
+		}
+		for _, f := range optionalStrings {
+			if v, _ := cmd.Flags().GetString(f.flag); v != "" {
+				body[f.key] = v
+			}
+		}
+
+		if tags, _ := cmd.Flags().GetStringArray("tag"); len(tags) > 0 {
+			body["tags"] = tags
+		}
+
+		// Required nested fields (must be provided).
+		for _, f := range []struct{ flag, key string }{
+			{"receipt-summary", "receipt_summary"},
+			{"payments", "payments"},
+		} {
+			v, err := parseJSONFlag(cmd, f.flag)
+			if err != nil {
+				return err
+			}
+			if v == nil {
+				return fmt.Errorf("--%s is required (JSON)", f.flag)
+			}
+			body[f.key] = v
+		}
+
+		// Optional nested fields.
+		for _, f := range []struct{ flag, key string }{
+			{"customer", "customer"},
+			{"employee", "employee"},
+			{"loyalty", "loyalty"},
+			{"line-items", "line_items"},
+			{"taxes", "taxes"},
+			{"event", "event"},
+			{"irn", "irn"},
+		} {
+			v, err := parseJSONFlag(cmd, f.flag)
+			if err != nil {
+				return err
+			}
+			if v != nil {
+				body[f.key] = v
+			}
+		}
+
+		client := cmdutil.NewClient()
+		data, err := client.Post(basePath, body)
+		if err != nil {
+			cmdutil.HandleErr(err)
+		}
+		api.PrettyPrint(data)
+		return nil
+	},
+}
+
+func init() {
+	// Required scalar flags.
+	createCmd.Flags().String("business-type", "", "Type of business: ecommerce, retail")
+	createCmd.Flags().String("business-category", "", "Business category: events, food_and_beverages, etc.")
+	createCmd.Flags().Int64("receipt-timestamp", 0, "UNIX timestamp when the receipt was generated")
+	createCmd.Flags().String("receipt-number", "", "Unique receipt number for the bill")
+	createCmd.Flags().String("receipt-type", "", "tax_invoice, sales_invoice, sales_return_invoice, etc.")
+	createCmd.Flags().String("receipt-delivery", "", "digital, print, digital_and_print")
+	_ = createCmd.MarkFlagRequired("business-type")
+	_ = createCmd.MarkFlagRequired("business-category")
+	_ = createCmd.MarkFlagRequired("receipt-timestamp")
+	_ = createCmd.MarkFlagRequired("receipt-number")
+	_ = createCmd.MarkFlagRequired("receipt-type")
+	_ = createCmd.MarkFlagRequired("receipt-delivery")
+
+	// Required nested flags (JSON).
+	createCmd.Flags().String("receipt-summary", "", "Receipt summary as JSON object (totals, taxes, discounts, payment_status)")
+	createCmd.Flags().String("payments", "", "Payments as JSON array of objects with method, currency, amount")
+	_ = createCmd.MarkFlagRequired("receipt-summary")
+	_ = createCmd.MarkFlagRequired("payments")
+
+	// Optional scalar flags.
+	createCmd.Flags().String("store-code", "", "Associated store code (required if multi-store setup)")
+	createCmd.Flags().String("bar-code-number", "", "Bar code generated after the transaction")
+	createCmd.Flags().String("qr-code-number", "", "QR code generated after the transaction")
+	createCmd.Flags().String("billing-pos-number", "", "POS number of the machine that generated the bill")
+	createCmd.Flags().String("pos-category", "", "POS machine type: traditional_pos, kiosk_pos")
+	createCmd.Flags().String("order-number", "", "Incremental order number of the generated bill")
+	createCmd.Flags().String("order-service-type", "", "Order service type: dine_in, take_away")
+	createCmd.Flags().String("delivery-status-url", "", "Order delivery status URL (ecommerce)")
+	createCmd.Flags().StringArray("tag", nil, "Tag for the invoice (repeatable)")
+
+	// Optional nested flags (JSON).
+	createCmd.Flags().String("customer", "", "Customer details as JSON object (required if receipt-delivery is digital)")
+	createCmd.Flags().String("employee", "", "Employee details as JSON array of objects")
+	createCmd.Flags().String("loyalty", "", "Customer loyalty details as JSON object")
+	createCmd.Flags().String("line-items", "", "Line items as JSON array of objects (required for some receipt types)")
+	createCmd.Flags().String("taxes", "", "Taxes as JSON array of objects (required for tax_invoice and similar)")
+	createCmd.Flags().String("event", "", "Event booking details as JSON object (required if business-category is events)")
+	createCmd.Flags().String("irn", "", "Invoice Reference Number details as JSON object")
+
+	Cmd.AddCommand(createCmd)
+}

--- a/cmd/bills/delete.go
+++ b/cmd/bills/delete.go
@@ -1,0 +1,28 @@
+package bills
+
+import (
+	"github.com/razorpay/razorpay-cli/api"
+	"github.com/razorpay/razorpay-cli/cmd/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete <bill_id>",
+	Short: "Delete a bill",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := cmdutil.NewClient()
+		data, err := client.Delete(basePath + "/" + args[0])
+		if err != nil {
+			cmdutil.HandleErr(err)
+		}
+		if len(data) > 0 {
+			api.PrettyPrint(data)
+		}
+		return nil
+	},
+}
+
+func init() {
+	Cmd.AddCommand(deleteCmd)
+}

--- a/cmd/bills/update.go
+++ b/cmd/bills/update.go
@@ -1,0 +1,130 @@
+package bills
+
+import (
+	"fmt"
+
+	"github.com/razorpay/razorpay-cli/api"
+	"github.com/razorpay/razorpay-cli/cmd/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update <bill_id>",
+	Short: "Update a bill (Billme receipt)",
+	Long: `Update a Razorpay Billme receipt.
+
+Scalar fields are passed as typed flags. Nested object and array-of-object
+fields (customer, employee, loyalty, line_items, receipt_summary, taxes,
+payments, irn) are passed as JSON strings.
+
+Example:
+  razorpay bills update bill_xyz \
+    --receipt-type tax_invoice \
+    --receipt-timestamp 1700000000 \
+    --receipt-delivery digital \
+    --receipt-summary '{"total":12000,"tax":2160}' \
+    --payments '[{"method":"upi","currency":"INR","amount":12000}]'`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		receiptType, _ := cmd.Flags().GetString("receipt-type")
+		receiptTimestamp, _ := cmd.Flags().GetInt64("receipt-timestamp")
+		receiptDelivery, _ := cmd.Flags().GetString("receipt-delivery")
+
+		if receiptTimestamp <= 0 {
+			return fmt.Errorf("--receipt-timestamp is required and must be > 0")
+		}
+
+		body := map[string]interface{}{
+			"receipt_type":      receiptType,
+			"receipt_timestamp": receiptTimestamp,
+			"receipt_delivery":  receiptDelivery,
+		}
+
+		// Optional scalar fields.
+		optionalStrings := []struct{ flag, key string }{
+			{"store-code", "store_code"},
+			{"pos-category", "pos_category"},
+		}
+		for _, f := range optionalStrings {
+			if v, _ := cmd.Flags().GetString(f.flag); v != "" {
+				body[f.key] = v
+			}
+		}
+
+		if tags, _ := cmd.Flags().GetStringArray("tag"); len(tags) > 0 {
+			body["tags"] = tags
+		}
+
+		// Required nested fields.
+		for _, f := range []struct{ flag, key string }{
+			{"receipt-summary", "receipt_summary"},
+			{"payments", "payments"},
+		} {
+			v, err := parseJSONFlag(cmd, f.flag)
+			if err != nil {
+				return err
+			}
+			if v == nil {
+				return fmt.Errorf("--%s is required (JSON)", f.flag)
+			}
+			body[f.key] = v
+		}
+
+		// Optional nested fields.
+		for _, f := range []struct{ flag, key string }{
+			{"customer", "customer"},
+			{"employee", "employee"},
+			{"loyalty", "loyalty"},
+			{"line-items", "line_items"},
+			{"taxes", "taxes"},
+			{"irn", "irn"},
+		} {
+			v, err := parseJSONFlag(cmd, f.flag)
+			if err != nil {
+				return err
+			}
+			if v != nil {
+				body[f.key] = v
+			}
+		}
+
+		client := cmdutil.NewClient()
+		data, err := client.Patch(basePath+"/"+args[0], body)
+		if err != nil {
+			cmdutil.HandleErr(err)
+		}
+		api.PrettyPrint(data)
+		return nil
+	},
+}
+
+func init() {
+	// Required scalar flags.
+	updateCmd.Flags().String("receipt-type", "", "tax_invoice, sales_invoice, sales_return_invoice, etc.")
+	updateCmd.Flags().Int64("receipt-timestamp", 0, "UNIX timestamp when the receipt was generated")
+	updateCmd.Flags().String("receipt-delivery", "", "digital, print, digital_and_print")
+	_ = updateCmd.MarkFlagRequired("receipt-type")
+	_ = updateCmd.MarkFlagRequired("receipt-timestamp")
+	_ = updateCmd.MarkFlagRequired("receipt-delivery")
+
+	// Required nested flags (JSON).
+	updateCmd.Flags().String("receipt-summary", "", "Receipt summary as JSON object")
+	updateCmd.Flags().String("payments", "", "Payments as JSON array of objects with method, currency, amount")
+	_ = updateCmd.MarkFlagRequired("receipt-summary")
+	_ = updateCmd.MarkFlagRequired("payments")
+
+	// Optional scalar flags.
+	updateCmd.Flags().String("store-code", "", "Associated store code")
+	updateCmd.Flags().String("pos-category", "", "POS machine type: traditional_pos, kiosk_pos")
+	updateCmd.Flags().StringArray("tag", nil, "Tag for the invoice (repeatable)")
+
+	// Optional nested flags (JSON).
+	updateCmd.Flags().String("customer", "", "Customer details as JSON object")
+	updateCmd.Flags().String("employee", "", "Employee details as JSON array of objects")
+	updateCmd.Flags().String("loyalty", "", "Customer loyalty details as JSON object")
+	updateCmd.Flags().String("line-items", "", "Line items as JSON array of objects")
+	updateCmd.Flags().String("taxes", "", "Taxes as JSON array of objects")
+	updateCmd.Flags().String("irn", "", "Invoice Reference Number details as JSON object")
+
+	Cmd.AddCommand(updateCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/razorpay/razorpay-cli/api"
+	"github.com/razorpay/razorpay-cli/cmd/bills"
 	"github.com/razorpay/razorpay-cli/cmd/cmdutil"
 	"github.com/razorpay/razorpay-cli/cmd/customers"
 	"github.com/razorpay/razorpay-cli/cmd/disputes"
@@ -72,4 +73,5 @@ func init() {
 	rootCmd.AddCommand(subscriptions.Cmd)
 	rootCmd.AddCommand(route.Cmd)
 	rootCmd.AddCommand(smartcollect.Cmd)
+	rootCmd.AddCommand(bills.Cmd)
 }


### PR DESCRIPTION
## Summary

Scaffolds 4 CLI commands for Razorpay **Billme** under `razorpay bills ...`, generated by syncing the docs repo against the current razorpay-cli command surface.

## Plan that was approved at the gate

| Label | DRAFT? | Command path | Source | Notes |
|---|---|---|---|---|
| NEW_RESOURCE | | bills (root) | api/billme/* | first-time wiring of `bills.Cmd` into root |
| NEW_METHOD | | bills create | api/billme/create-bill.md | nested-body fields via JSON-string flags |
| NEW_METHOD | | bills update | api/billme/update-bill.md | nested-body fields via JSON-string flags |
| NEW_METHOD | | bills delete | api/billme/delete-bill.md | clean DELETE, mirrors invoices delete |

Bills here = Razorpay **Billme** (digital receipts), **not** BBPS bill payments. Confirmed during plan review.

## Generated files

- `cmd/bills/bills.go` — root `bills` command + `parseJSONFlag` helper for nested-object body params
- `cmd/bills/create.go` — `POST /v1/bills`
- `cmd/bills/update.go` — `PATCH /v1/bills/{id}`
- `cmd/bills/delete.go` — `DELETE /v1/bills/{id}`
- `cmd/root.go` — registers `bills.Cmd`

## Convention notes for the reviewer

- **No tests:** this repo currently has zero `*_test.go` files. The skill follows the existing convention and does not generate tests. See the existing `cmd/invoices/`, `cmd/payments/` etc. — none have tests either.
- **Nested-body fields:** `customer`, `line_items`, `receipt_summary`, `payments`, `taxes`, etc. are passed as JSON-string flags (`--customer '{"name":"Alice"}'`) parsed at runtime via `parseJSONFlag`. Required nested fields use `MarkFlagRequired` plus a runtime nil-check. This pattern was agreed during the Bills sync as the canonical approach for deep request bodies — see `cmd/bills/bills.go` for the helper.
- **Conditional requirements** (e.g. *"required if business_category is events"*) are surfaced in each command's `Long` description rather than encoded as flag rules. Cobra's `MarkFlagRequired` is unconditional, and server-side validation is authoritative.

## Provenance

Generated by the [sync-cli-from-docs Claude skill](https://github.com/anthropics/claude-code).
- Branch: `ai-week/sync-bills-20260506-011736`
- Base: `added_apis_for_cli`
