### PR TITLE
feat: identify CLI to API via User-Agent header

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -18,6 +19,18 @@ import (
 )
 
 const defaultBaseURL = "https://api.razorpay.com"
+
+// userAgent identifies the CLI to the Razorpay API on every request.
+// Format: "Razorpay-CLI/<version> (<os>/<arch>)" 
+var userAgent = buildUserAgent("dev")
+
+func buildUserAgent(version string) string {
+	return fmt.Sprintf("Razorpay-CLI/%s (%s/%s)", version, runtime.GOOS, runtime.GOARCH)
+}
+
+func SetUserAgentVersion(version string) {
+	userAgent = buildUserAgent(version)
+}
 
 type Client struct {
 	keyID     string
@@ -74,6 +87,7 @@ func (c *Client) doWithHeaders(method, path string, body interface{}, query url.
 		return nil, err
 	}
 	req.SetBasicAuth(c.keyID, c.keySecret)
+	req.Header.Set("User-Agent", userAgent)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -161,6 +175,7 @@ func (c *Client) PostMultipart(path string, filePath string, fields map[string]s
 		return nil, err
 	}
 	req.SetBasicAuth(c.keyID, c.keySecret)
+	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", w.FormDataContentType())
 
 	resp, err := c.http.Do(req)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,9 +42,12 @@ For help on a specific command, run:
 
 // SetVersion stamps the root command with build-time version info injected
 // by goreleaser via -ldflags "-X main.version=... -X main.commit=... -X main.date=..."
+// The version is also pushed to the api package so every HTTP request
+// carries a User-Agent identifying this CLI build.
 func SetVersion(version, commit, date string) {
 	rootCmd.Version = version
 	rootCmd.Long = rootCmd.Long + "\n\nVersion: " + version + " (" + commit + ") built " + date
+	api.SetUserAgentVersion(version)
 }
 
 func Execute() {


### PR DESCRIPTION
## Summary

- Sets a `User-Agent` header on every HTTP request the CLI makes, of the form `Razorpay-CLI/<version> (<os>/<arch>)` — e.g. `Razorpay-CLI/v1.0.8 (darwin/arm64)`
- Mirrors the convention used by every official Razorpay SDK (`razorpay-python`, `razorpay-node`, `razorpay-java`, `razorpay-php`, `razorpay-ruby`, `razorpay-dot-net`), so backend analytics can attribute API calls to the CLI and slice by version / platform
- No new dependencies, no new endpoints — telemetry rides the existing HTTP request the way every SDK does

## What changed

**`api/client.go`**
- Package-level `userAgent` var, initialised to `Razorpay-CLI/dev (<os>/<arch>)` so requests built without ldflags (e.g. `go build` / `go run .` / tests) still carry a valid UA
- `buildUserAgent(version)` helper builds the string from `runtime.GOOS` + `runtime.GOARCH`
- `SetUserAgentVersion(version)` lets the cmd layer push the real ldflag-injected version once at startup
- `req.Header.Set(\"User-Agent\", userAgent)` added to **both** request paths: `doWithHeaders` and `PostMultipart`

**`cmd/root.go`**
- `cmd.SetVersion` now also calls `api.SetUserAgentVersion(version)` so the version baked in by `-ldflags \"-X main.version=...\"` reaches the api package

## Verified end-to-end

Built locally with `make build`, installed to `/usr/local/bin/razorpay`, ran `razorpay orders create` against the live API. Server-side canonical log line confirms the header arrives correctly:

\`\`\`
user_agent.original: \"Razorpay-CLI/v1.0.8-5-gebaeea8-dirty (darwin/arm64)\"
http.request.method: POST
url.path:            /v1/orders
http.status_code:    200
order.id:            T1sqHEwcuPXuTz
\`\`\`

## Test plan

- [ ] `make build && ./razorpay --version` — version reflects ldflag injection
- [ ] `./razorpay orders list --count 1` (against test key) — request succeeds
- [ ] Backend log search confirms `User-Agent` header lands as `Razorpay-CLI/<version> (<os>/<arch>)`
- [ ] `go run . orders list --count 1` — falls back to `Razorpay-CLI/dev (...)` (no ldflags) but still sends a valid UA
- [ ] `make test` (e2e suite) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)