### PR TITLE
feat: nudge users when a new release is available

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/razorpay/razorpay-cli/cmd/settlements"
 	smartcollect "github.com/razorpay/razorpay-cli/cmd/smart-collect"
 	"github.com/razorpay/razorpay-cli/cmd/subscriptions"
+	"github.com/razorpay/razorpay-cli/update"
 	"github.com/spf13/cobra"
 )
 
@@ -38,6 +39,10 @@ Then run any resource command, for example:
 For help on a specific command, run:
 
   razorpay <command> --help`,
+	// Fires after every subcommand (Cobra skips it on error).
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		update.CheckOnce(cmd.Root().Version)
+	},
 }
 
 // SetVersion stamps the root command with build-time version info injected

--- a/update/cache.go
+++ b/update/cache.go
@@ -1,0 +1,61 @@
+// Package update prints a once-a-day notice when a newer release exists.
+package update
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const cacheFileName = "version-check.json"
+
+type cache struct {
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+func cachePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".razorpay", cacheFileName), nil
+}
+
+// readCache returns the zero value on any error (missing, unreadable, malformed).
+func readCache() cache {
+	path, err := cachePath()
+	if err != nil {
+		return cache{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cache{}
+	}
+	var c cache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return cache{}
+	}
+	return c
+}
+
+// writeCache writes atomically (temp file + rename) so concurrent processes
+// can't tear the file.
+func writeCache(c cache) error {
+	path, err := cachePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/update/check.go
+++ b/update/check.go
@@ -1,0 +1,54 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+const checkInterval = 24 * time.Hour
+
+// CheckOnce prints a notice to stderr if a newer release exists. Throttled to
+// once per checkInterval via ~/.razorpay/version-check.json. Silent on every
+// failure path.
+func CheckOnce(currentVersion string) {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		return
+	}
+
+	c := readCache()
+	// elapsed > 0 guards against a future-dated cache (clock skew) trapping us.
+	elapsed := time.Since(c.CheckedAt)
+	if elapsed > 0 && elapsed < checkInterval {
+		return
+	}
+
+	latest, err := fetchLatestVersion(context.Background())
+	if err != nil {
+		return
+	}
+
+	_ = writeCache(cache{CheckedAt: time.Now().UTC()})
+
+	if isNewer(latest, currentVersion) {
+		fmt.Fprintf(os.Stderr,
+			"\nA new version of razorpay is available: %s. See https://razorpay.com/docs/api/install-cli/ to upgrade.\n\n",
+			latest)
+	}
+}
+
+// isNewer returns true when current is "dev" (unstamped build) or differs
+// from latest after trimming the optional "v" prefix.
+func isNewer(latest, current string) bool {
+	if latest == "" {
+		return false
+	}
+	if current == "" || current == "dev" {
+		return true
+	}
+	return strings.TrimPrefix(latest, "v") != strings.TrimPrefix(current, "v")
+}

--- a/update/releases.go
+++ b/update/releases.go
@@ -1,0 +1,48 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const releasesURL = "https://api.github.com/repos/razorpay/razorpay-cli/releases/latest"
+
+const fetchTimeout = 3 * time.Second
+
+func fetchLatestVersion(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesURL, nil)
+	if err != nil {
+		return "", err
+	}
+	// GitHub returns 403 without a User-Agent.
+	req.Header.Set("User-Agent", "razorpay-cli-update-check")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github releases endpoint returned %d", resp.StatusCode)
+	}
+
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	return body.TagName, nil
+}


### PR DESCRIPTION
## Summary

- After every \`razorpay\` subcommand, checks whether a newer release exists on GitHub and prints a one-line notice to stderr if so
- Throttled to once per 24h via a tiny JSON cache at \`~/.razorpay/version-check.json\` so we hit GitHub at most once a day per user
- Silent on every failure path (no network, GitHub down, malformed cache, non-TTY stderr) — never breaks the user's command

## How it looks

\`\`\`
\$ razorpay payments list --count 1
{
  \"count\": 1,
  \"entity\": \"collection\",
  \"items\": [ ... ]
}

A new version of razorpay is available: v1.0.9. See https://razorpay.com/docs/api/install-cli/ to upgrade.
\`\`\`

Notice goes to **stderr**, so piping to \`jq\` etc. is unaffected:

\`\`\`
\$ razorpay payments list --count 1 | jq '.count'
1
A new version of razorpay is available: ...   ← still printed to terminal
\`\`\`

## What changed

| File | Purpose |
| --- | --- |
| \`update/cache.go\` | Read/write \`~/.razorpay/version-check.json\` (single \`checked_at\` timestamp). Atomic write via temp + rename. |
| \`update/releases.go\` | Fetch latest tag from \`https://api.github.com/repos/razorpay/razorpay-cli/releases/latest\` with a 3s timeout. |
| \`update/check.go\` | \`CheckOnce()\`: TTY guard, 24h throttle, fetch, compare, notify. |
| \`cmd/root.go\` | \`PersistentPostRun\` calls \`update.CheckOnce(rootCmd.Version)\` after every subcommand. Cobra skips this on errored commands, so failed runs don't get a stacked notice. |

## Test plan

- [ ] First run on a clean system creates \`~/.razorpay/version-check.json\` and prints the notice if behind latest
- [ ] Second invocation within 24h is silent
- [ ] \`razorpay payments list --count 1 | jq '.count'\` still outputs just the count on stdout (notice on stderr doesn't pollute pipes)
- [ ] Running with stderr redirected (\`razorpay payments list 2>/dev/null\`) suppresses the notice entirely
- [ ] Non-TTY stderr (CI, scripts) is silent — verified via \`make test\`
- [ ] No network / GitHub 503: command returns its normal output, notice silent, cache file is NOT updated (so next run will retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)