### PR TITLE
feat: CLI telemetry — User-Agent header + once-a-day update check

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -18,6 +19,18 @@ import (
 )
 
 const defaultBaseURL = "https://api.razorpay.com"
+
+// userAgent identifies the CLI to the Razorpay API on every request.
+// Format: "Razorpay-CLI/<version> (<os>/<arch>)" 
+var userAgent = buildUserAgent("dev")
+
+func buildUserAgent(version string) string {
+	return fmt.Sprintf("Razorpay-CLI/%s (%s/%s)", version, runtime.GOOS, runtime.GOARCH)
+}
+
+func SetUserAgentVersion(version string) {
+	userAgent = buildUserAgent(version)
+}
 
 type Client struct {
 	keyID     string
@@ -74,6 +87,7 @@ func (c *Client) doWithHeaders(method, path string, body interface{}, query url.
 		return nil, err
 	}
 	req.SetBasicAuth(c.keyID, c.keySecret)
+	req.Header.Set("User-Agent", userAgent)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -161,6 +175,7 @@ func (c *Client) PostMultipart(path string, filePath string, fields map[string]s
 		return nil, err
 	}
 	req.SetBasicAuth(c.keyID, c.keySecret)
+	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", w.FormDataContentType())
 
 	resp, err := c.http.Do(req)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/razorpay/razorpay-cli/cmd/settlements"
 	smartcollect "github.com/razorpay/razorpay-cli/cmd/smart-collect"
 	"github.com/razorpay/razorpay-cli/cmd/subscriptions"
+	"github.com/razorpay/razorpay-cli/update"
 	"github.com/spf13/cobra"
 )
 
@@ -38,6 +39,10 @@ Then run any resource command, for example:
 For help on a specific command, run:
 
   razorpay <command> --help`,
+	// Fires after every subcommand (Cobra skips it on error).
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		update.CheckOnce(cmd.Root().Version)
+	},
 }
 
 // SetVersion stamps the root command with build-time version info injected

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,9 +42,12 @@ For help on a specific command, run:
 
 // SetVersion stamps the root command with build-time version info injected
 // by goreleaser via -ldflags "-X main.version=... -X main.commit=... -X main.date=..."
+// The version is also pushed to the api package so every HTTP request
+// carries a User-Agent identifying this CLI build.
 func SetVersion(version, commit, date string) {
 	rootCmd.Version = version
 	rootCmd.Long = rootCmd.Long + "\n\nVersion: " + version + " (" + commit + ") built " + date
+	api.SetUserAgentVersion(version)
 }
 
 func Execute() {

--- a/update/cache.go
+++ b/update/cache.go
@@ -1,0 +1,61 @@
+// Package update prints a once-a-day notice when a newer release exists.
+package update
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const cacheFileName = "version-check.json"
+
+type cache struct {
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+func cachePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".razorpay", cacheFileName), nil
+}
+
+// readCache returns the zero value on any error (missing, unreadable, malformed).
+func readCache() cache {
+	path, err := cachePath()
+	if err != nil {
+		return cache{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cache{}
+	}
+	var c cache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return cache{}
+	}
+	return c
+}
+
+// writeCache writes atomically (temp file + rename) so concurrent processes
+// can't tear the file.
+func writeCache(c cache) error {
+	path, err := cachePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/update/check.go
+++ b/update/check.go
@@ -1,0 +1,54 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+const checkInterval = 24 * time.Hour
+
+// CheckOnce prints a notice to stderr if a newer release exists. Throttled to
+// once per checkInterval via ~/.razorpay/version-check.json. Silent on every
+// failure path.
+func CheckOnce(currentVersion string) {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		return
+	}
+
+	c := readCache()
+	// elapsed > 0 guards against a future-dated cache (clock skew) trapping us.
+	elapsed := time.Since(c.CheckedAt)
+	if elapsed > 0 && elapsed < checkInterval {
+		return
+	}
+
+	latest, err := fetchLatestVersion(context.Background())
+	if err != nil {
+		return
+	}
+
+	_ = writeCache(cache{CheckedAt: time.Now().UTC()})
+
+	if isNewer(latest, currentVersion) {
+		fmt.Fprintf(os.Stderr,
+			"\nA new version of razorpay is available: %s. See https://razorpay.com/docs/api/install-cli/ to upgrade.\n\n",
+			latest)
+	}
+}
+
+// isNewer returns true when current is "dev" (unstamped build) or differs
+// from latest after trimming the optional "v" prefix.
+func isNewer(latest, current string) bool {
+	if latest == "" {
+		return false
+	}
+	if current == "" || current == "dev" {
+		return true
+	}
+	return strings.TrimPrefix(latest, "v") != strings.TrimPrefix(current, "v")
+}

--- a/update/releases.go
+++ b/update/releases.go
@@ -1,0 +1,48 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const releasesURL = "https://api.github.com/repos/razorpay/razorpay-cli/releases/latest"
+
+const fetchTimeout = 3 * time.Second
+
+func fetchLatestVersion(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesURL, nil)
+	if err != nil {
+		return "", err
+	}
+	// GitHub returns 403 without a User-Agent.
+	req.Header.Set("User-Agent", "razorpay-cli-update-check")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github releases endpoint returned %d", resp.StatusCode)
+	}
+
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	return body.TagName, nil
+}


### PR DESCRIPTION
Combines #18 and #19 into a single PR. Closing those.

## Summary

Two related changes that together give the CLI basic telemetry + a way to nudge users on stale versions:

### 1. User-Agent header on every API call
Every CLI request now carries:
\`\`\`
User-Agent: Razorpay-CLI/<version> (<os>/<arch>)
\`\`\`
e.g. \`Razorpay-CLI/v1.0.8 (darwin/arm64)\`. Mirrors the convention used by every official Razorpay SDK (razorpay-python, razorpay-node, etc.) so backend analytics can attribute API calls to the CLI and slice by version / platform.

### 2. Once-a-day "new version available" notice
After every \`razorpay\` subcommand, if a newer release exists on GitHub, prints a one-line notice to stderr:
\`\`\`
A new version of razorpay is available: v1.0.9. See https://razorpay.com/docs/api/install-cli/ to upgrade.
\`\`\`
Throttled via \`~/.razorpay/version-check.json\` so we hit GitHub at most once a day per user. Silent on every failure path (no network, non-TTY stderr, malformed cache) — never breaks the user's command.

## What changed

| File | Purpose |
| --- | --- |
| \`api/client.go\` | UA header set on every outbound request (both \`doWithHeaders\` and \`PostMultipart\`). Default \`dev\` falls back when built without ldflags. |
| \`update/cache.go\` | Read/write \`~/.razorpay/version-check.json\` (single \`checked_at\` timestamp). Atomic write via temp + rename. |
| \`update/releases.go\` | Fetch latest tag from GitHub's \`/releases/latest\` endpoint with a 3s timeout. |
| \`update/check.go\` | \`CheckOnce()\`: TTY guard, 24h throttle, fetch, compare, notify. |
| \`cmd/root.go\` | \`cmd.SetVersion\` pushes the build's version into the api package's UA. \`PersistentPostRun\` calls \`update.CheckOnce\` after every subcommand. |

## How it looks

\`\`\`
\$ razorpay payments list --count 1
{
  \"count\": 1,
  \"entity\": \"collection\",
  ...
}

A new version of razorpay is available: v1.0.9. See https://razorpay.com/docs/api/install-cli/ to upgrade.
\`\`\`

Notice goes to **stderr**, so piping to \`jq\` etc. is unaffected:
\`\`\`
\$ razorpay payments list --count 1 | jq '.count'
1
\`\`\`

## Verified end-to-end

Server-side canonical log lines from \`order-service\`:
\`\`\`
user_agent.original: \"Razorpay-CLI/v1.0.8-... (darwin/arm64)\"
\`\`\`
And from \`edge\`:
\`\`\`
http_user_agent: \"Razorpay-CLI/v1.0.8-... (darwin/arm64)\"
\`\`\`
Both fields confirmed visible in Coralogix, so dashboards can be built from the field.

## Test plan

- [ ] \`make build && ./razorpay --version\` — version reflects ldflag injection
- [ ] \`./razorpay orders list --count 1\` against test key — succeeds, header sent
- [ ] First-ever run on a clean system creates \`~/.razorpay/version-check.json\` and prints the notice if behind latest
- [ ] Second invocation within 24h is silent
- [ ] \`razorpay payments list --count 1 | jq '.count'\` outputs just \`1\` (notice on stderr doesn't pollute the pipe)
- [ ] Running with stderr redirected (\`razorpay payments list 2>/dev/null\`) suppresses the notice
- [ ] Non-TTY stderr (CI, scripts) is silent
- [ ] No network / GitHub 503: command returns normal output, notice silent, cache NOT updated (so next run retries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)