### PR TITLE
docs: remove README links to files that do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,8 @@ cmd/
 api/                 HTTP client — auth, JSON pretty-print, multipart upload
 config/              config file + env-var loader (viper)
 tests/               end-to-end test suite (build tag `e2e`)
-docs/                per-resource usage guides
+docs/                installation guide
 install.sh           platform installer
-AGENTS.md            agent guidance for this repo
 CHANGELOG.md         release notes
 ```
 
@@ -241,6 +240,7 @@ See [tests/README.md](tests/README.md) for the layout of the test suite and how 
 ## Documentation
 
 - [docs/install.md](docs/install.md) — platform-specific install
-- Per-resource guides: [payments](docs/payments.md) · [orders](docs/orders.md) · [customers](docs/customers.md) · [refunds](docs/refunds.md) · [settlements](docs/settlements.md) · [disputes](docs/disputes.md)
 - [CHANGELOG.md](CHANGELOG.md) — release notes
-- [AGENTS.md](AGENTS.md) — agent guidance for working in this repository
+- [Razorpay API reference](https://razorpay.com/docs/api/) — field-level reference for every endpoint the CLI wraps
+
+For per-command usage, run `razorpay <group> --help` — for example `razorpay payments --help`. Every command lists its flags, defaults and accepted values.


### PR DESCRIPTION
Fixes #17.

The README's Documentation section and repository-layout block advertise seven files that have never existed in the tree: six per-resource guides under `docs/`, and `AGENTS.md`. Clicking any of them from GitHub gives a 404. `docs/` contains only `install.md`.

#17 offered two options — write the missing guides, or drop the links until they exist. This takes the second. Writing six resource guides is a much larger piece of work and shouldn't block the README being accurate, and the content largely exists already: every command self-documents through `--help`, and the field-level semantics live in the Razorpay API reference.

## Changes

**Documentation section** — dropped the per-resource link list and the `AGENTS.md` link. Added a pointer to the Razorpay API reference for field-level detail, and a line directing readers to `razorpay <group> --help` for per-command usage.

**Repository layout** — `docs/` was described as "per-resource usage guides"; it is an installation guide. Removed the `AGENTS.md` entry.

## Verification

Walked every relative Markdown link in `*.md`, `docs/*.md` and `tests/*.md` and resolved it against the tree — 0 broken links remain (was 7).

`go build ./...`, `go vet ./...` and `go test ./...` all pass. No Go files are touched by this change.

Note for whoever picks this up: if the per-resource guides are still on the roadmap, reverting this commit restores the exact link list once the files land.
