### PR TITLE
docs: correct install location in README to ~/.local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the latest release for your platform:
 curl -fsSL https://razorpay.com/cli/latest/install.sh | bash
 ```
 
-The script downloads the right tarball for your OS/arch, extracts the `razorpay` binary, and places it at `/usr/local/bin/razorpay`. Confirm the install:
+The script downloads the right tarball for your OS/arch, extracts the `razorpay` binary, and places it at `~/.local/bin/razorpay`. If that directory is not already on your `PATH`, the script appends it to your shell profile — open a new terminal, or `source` the profile, before the command resolves. Confirm the install:
 
 ```bash
 $ razorpay --version


### PR DESCRIPTION
Fixes #30.

`README.md` tells the reader that `install.sh` places the binary at `/usr/local/bin/razorpay`. It does not — `install.sh:5` sets `INSTALL_DIR="$HOME/.local/bin"`. `docs/install.md:14` already documents this correctly, so only the README was out of sync.

The difference is user-visible rather than cosmetic. `/usr/local/bin` is on `PATH` by default; `~/.local/bin` frequently is not, which is why `install.sh:57-75` appends an `export PATH=...` line to the user's shell profile and prints a note about opening a new terminal. A reader trusting the README expects a system-wide install that needs no `PATH` change, then can't explain why `razorpay` isn't found in the shell they just ran the installer in.

## Changes

Corrected the path, and documented the `PATH` behaviour the script actually performs so the follow-up step isn't a surprise.

## Verification

`install.sh:5` and `docs/install.md:14` both confirm `~/.local/bin`. `go build ./...`, `go vet ./...` and `go test ./...` pass; no Go files are touched.
