### PR TITLE
fix: harden credential handling in the API client, config store and installer

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -36,23 +37,63 @@ type Client struct {
 	keyID     string
 	keySecret string
 	baseURL   string
+	baseErr   error
 	http      *http.Client
 }
 
 func New(keyID, keySecret string) *Client {
-	base := os.Getenv("RAZORPAY_BASE_URL")
-	if base == "" {
-		base = defaultBaseURL
-	}
+	base, err := resolveBaseURL()
 	return &Client{
 		keyID:     keyID,
 		keySecret: keySecret,
 		baseURL:   base,
+		baseErr:   err,
 		http:      &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
-func (c *Client) requireAuth() error {
+// resolveBaseURL returns the API base URL, honouring the RAZORPAY_BASE_URL
+// override. The override is useful for pointing the CLI at a local or staging
+// endpoint, but every request carries the API key in an Authorization header,
+// so the override is validated and is never applied silently.
+func resolveBaseURL() (string, error) {
+	override := strings.TrimSpace(os.Getenv("RAZORPAY_BASE_URL"))
+	if override == "" {
+		return defaultBaseURL, nil
+	}
+
+	u, err := url.Parse(override)
+	if err != nil {
+		return "", fmt.Errorf("RAZORPAY_BASE_URL %q is not a valid URL: %w", override, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("RAZORPAY_BASE_URL %q must include a scheme and host, e.g. https://api.razorpay.com", override)
+	}
+	// Plain HTTP would put the API key on the wire in cleartext. Loopback is
+	// allowed so the endpoint can be pointed at a local test server.
+	if u.Scheme != "https" && !isLoopback(u.Hostname()) {
+		return "", fmt.Errorf("RAZORPAY_BASE_URL %q uses %s; only https is accepted for non-loopback hosts, because API credentials are sent with every request", override, u.Scheme)
+	}
+
+	base := strings.TrimSuffix(override, "/")
+	fmt.Fprintln(os.Stderr, "warning: RAZORPAY_BASE_URL is set — sending API requests to "+base+" instead of "+defaultBaseURL)
+	return base, nil
+}
+
+func isLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// preflight reports whether the client is safe to send a request with: the
+// endpoint must be valid and the credentials must be present.
+func (c *Client) preflight() error {
+	if c.baseErr != nil {
+		return c.baseErr
+	}
 	if c.keyID == "" || c.keySecret == "" {
 		return fmt.Errorf("API credentials not configured; run 'razorpay configure' or set the RAZORPAY_KEY_ID and RAZORPAY_KEY_SECRET environment variables")
 	}
@@ -64,7 +105,7 @@ func (c *Client) do(method, path string, body interface{}, query url.Values) ([]
 }
 
 func (c *Client) doWithHeaders(method, path string, body interface{}, query url.Values, extraHeaders map[string]string) ([]byte, error) {
-	if err := c.requireAuth(); err != nil {
+	if err := c.preflight(); err != nil {
 		return nil, err
 	}
 
@@ -142,7 +183,7 @@ func (c *Client) PostWithHeaders(path string, body interface{}, headers map[stri
 
 // PostMultipart uploads a file and additional form fields using multipart/form-data.
 func (c *Client) PostMultipart(path string, filePath string, fields map[string]string) ([]byte, error) {
-	if err := c.requireAuth(); err != nil {
+	if err := c.preflight(); err != nil {
 		return nil, err
 	}
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		want    string
+		wantErr string
+	}{
+		{name: "unset falls back to the default", env: "", want: defaultBaseURL},
+		{name: "https override is accepted", env: "https://api-staging.razorpay.com", want: "https://api-staging.razorpay.com"},
+		{name: "trailing slash is trimmed", env: "https://api-staging.razorpay.com/", want: "https://api-staging.razorpay.com"},
+		{name: "loopback IPv4 may use http", env: "http://127.0.0.1:8791", want: "http://127.0.0.1:8791"},
+		{name: "localhost may use http", env: "http://localhost:8791", want: "http://localhost:8791"},
+		{name: "loopback IPv6 may use http", env: "http://[::1]:8791", want: "http://[::1]:8791"},
+
+		{name: "plain http to a remote host is rejected", env: "http://example.com", wantErr: "only https"},
+		{name: "non-loopback IP over http is rejected", env: "http://203.0.113.10", wantErr: "only https"},
+		{name: "a bare hostname is rejected", env: "api.example.com", wantErr: "must include a scheme and host"},
+		{name: "a non-http scheme is rejected", env: "ftp://example.com", wantErr: "only https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("RAZORPAY_BASE_URL", tt.env)
+
+			got, err := resolveBaseURL()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected an error containing %q, got base %q and nil error", tt.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected an error containing %q, got: %v", tt.wantErr, err)
+				}
+				if got != "" {
+					t.Errorf("expected an empty base URL alongside the error, got %q", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("base URL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A rejected override must surface as a request error rather than quietly
+// falling back to the real API.
+func TestClientRefusesToSendWithAnInvalidBaseURL(t *testing.T) {
+	t.Setenv("RAZORPAY_BASE_URL", "http://example.com")
+
+	c := New("rzp_test_key", "secret")
+
+	if _, err := c.Get("/v1/payments", nil); err == nil {
+		t.Fatal("expected Get to fail while the base URL is invalid, got nil error")
+	}
+	if c.baseURL == defaultBaseURL {
+		t.Errorf("client silently fell back to %s instead of holding the error", defaultBaseURL)
+	}
+}
+
+// Credentials are still required once the endpoint is valid.
+func TestPreflightRequiresCredentials(t *testing.T) {
+	t.Setenv("RAZORPAY_BASE_URL", "")
+
+	if err := New("", "").preflight(); err == nil {
+		t.Fatal("expected an error when no credentials are configured")
+	}
+	if err := New("rzp_test_key", "secret").preflight(); err != nil {
+		t.Fatalf("unexpected error with credentials set: %v", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -78,5 +78,17 @@ func Save(keyID, keySecret string) error {
 
 	viper.Set("key_id", keyID)
 	viper.Set("key_secret", keySecret)
-	return viper.WriteConfigAs(filepath.Join(dir, configFile+"."+configType))
+
+	// This file holds a live API key secret. Viper defaults to 0644, which
+	// leaves it readable by every user on the machine.
+	viper.SetConfigPermissions(0600)
+
+	path := filepath.Join(dir, configFile+"."+configType)
+	if err := viper.WriteConfigAs(path); err != nil {
+		return err
+	}
+
+	// OpenFile only applies the mode when it creates the file, so a config
+	// written by an older version keeps its original 0644. Narrow it here.
+	return os.Chmod(path, 0600)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// The config file holds a live API key secret, so it must not be readable by
+// other users on the machine.
+func TestSaveWritesConfigOwnerReadableOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file modes are not meaningful on Windows")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := Save("rzp_test_key", "secret"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(home, configDir, configFile+"."+configType))
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("config file mode = %#o, want 0600", got)
+	}
+}
+
+// A config written by an older version is 0644. Saving again must narrow it,
+// which WriteConfigAs alone does not do -- OpenFile only applies the mode when
+// it creates the file.
+func TestSaveNarrowsPermissionsOnAnExistingConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file modes are not meaningful on Windows")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, configDir)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, configFile+"."+configType)
+	if err := os.WriteFile(path, []byte("key_id: old"), 0644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if err := Save("rzp_test_key", "secret"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("config file mode = %#o, want 0600 after re-save", got)
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,8 @@ OS="$(uname -s)"
 ARCH="$(uname -m)"
 
 case "$OS" in
-  Darwin) OS_NAME="mac-os" ;;
-  Linux)  OS_NAME="linux" ;;
+  Darwin) OS_NAME="mac-os"; CHECKSUM_OS="mac" ;;
+  Linux)  OS_NAME="linux";  CHECKSUM_OS="linux" ;;
   *)
     echo "Unsupported OS: $OS"
     exit 1
@@ -30,14 +30,57 @@ case "$ARCH" in
 esac
 
 # ---------------------------------------------------------------------------
-# Download and extract
+# Download
 # ---------------------------------------------------------------------------
 ARCHIVE="${BINARY}_${OS_NAME}_${ARCH_NAME}.tar.gz"
 URL="${BASE_URL}/${ARCHIVE}"
 TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 echo "Downloading ${ARCHIVE}..."
 curl -fsSL "$URL" -o "$TMP_DIR/$ARCHIVE"
+
+# ---------------------------------------------------------------------------
+# Verify checksum
+#
+# The published checksum file lists the *versioned* archive name, while the
+# latest/ prefix serves it without the version -- so resolve the version and
+# rebuild the name to look it up.
+# ---------------------------------------------------------------------------
+echo "Verifying checksum..."
+
+VERSION="$(curl -fsSL "${BASE_URL}/version")"
+VERSION_NUM="${VERSION#v}"
+CHECKSUM_FILE="${BINARY}-${CHECKSUM_OS}-checksums.txt"
+curl -fsSL "${BASE_URL}/${CHECKSUM_FILE}" -o "$TMP_DIR/$CHECKSUM_FILE"
+
+VERSIONED_ARCHIVE="${BINARY}_${VERSION_NUM}_${OS_NAME}_${ARCH_NAME}.tar.gz"
+EXPECTED_SHA="$(awk -v name="$VERSIONED_ARCHIVE" '$2 == name { print $1 }' "$TMP_DIR/$CHECKSUM_FILE")"
+
+if [ -z "$EXPECTED_SHA" ]; then
+  echo "Error: no checksum published for ${VERSIONED_ARCHIVE} in ${CHECKSUM_FILE}." >&2
+  echo "Refusing to install an unverified binary." >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL_SHA="$(sha256sum "$TMP_DIR/$ARCHIVE" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL_SHA="$(shasum -a 256 "$TMP_DIR/$ARCHIVE" | awk '{ print $1 }')"
+else
+  echo "Error: neither sha256sum nor shasum is available; cannot verify the download." >&2
+  exit 1
+fi
+
+if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+  echo "Error: checksum mismatch for ${ARCHIVE}." >&2
+  echo "  expected: ${EXPECTED_SHA}" >&2
+  echo "  actual:   ${ACTUAL_SHA}" >&2
+  echo "Refusing to install. Please report this at https://github.com/razorpay/razorpay-cli/issues" >&2
+  exit 1
+fi
+
+echo "Checksum verified (${VERSION})."
 
 echo "Extracting..."
 tar -xzf "$TMP_DIR/$ARCHIVE" -C "$TMP_DIR"
@@ -48,8 +91,6 @@ tar -xzf "$TMP_DIR/$ARCHIVE" -C "$TMP_DIR"
 mkdir -p "$INSTALL_DIR"
 mv "$TMP_DIR/$BINARY" "$INSTALL_DIR/$BINARY"
 chmod +x "$INSTALL_DIR/$BINARY"
-
-rm -rf "$TMP_DIR"
 
 # ---------------------------------------------------------------------------
 # Ensure ~/.local/bin is in PATH


### PR DESCRIPTION
Fixes #29.

Three independent gaps in how the CLI handles a live API key pair — one in how the binary is delivered, one in how the secret is stored, one in where the secret is sent. Each is separately revertable; grouped because they share the root cause described in #29.

## 1. `install.sh` now verifies the download (`install.sh`)

The documented install path fetched a tarball over HTTPS and extracted it straight onto `PATH` with no verification, while `razorpay-<os>-checksums.txt` sat unused in the same S3 prefix.

The script now resolves `latest/version`, rebuilds the versioned archive name that GoReleaser records in the checksum file (`razorpay_1.0.9_linux_x86_64.tar.gz`, vs the version-stripped name served from `latest/`), looks up the expected SHA-256 and compares before extracting. `sha256sum` with a `shasum -a 256` fallback covers Linux and macOS. Any mismatch, missing checksum line, or missing hashing tool aborts before anything is written to `PATH`. Also added a `trap` so the temp dir is cleaned on the failure paths, which the previous unconditional `rm -rf` at the end did not cover.

## 2. Config file is no longer world-readable (`config/config.go`)

`viper.WriteConfigAs` uses Viper's default `configPermissions` of `0644`, so `~/.razorpay/config.yaml` — which holds `key_secret` in plaintext — was written `-rw-r--r--`. Now `0600`.

`OpenFile` only applies a mode when it *creates* the file, so an existing config written by an older version would keep its `0644`. The explicit `os.Chmod` after the write narrows those too, so the fix reaches existing installs rather than only new ones.

## 3. `RAZORPAY_BASE_URL` is validated instead of trusted (`api/client.go`)

The override was applied with no checks and no output, while every request carries the key pair in an `Authorization` header. `http://` was accepted, so the secret could go to an arbitrary host in cleartext — and because the CLI prints whatever it gets back, a `200` from that host made `refunds create` report success for a refund that never happened.

`resolveBaseURL` now requires a scheme and host, and requires `https` unless the host is loopback (so pointing at a local test server still works). It prints a one-line stderr warning whenever the override is active, so it can never be silent. A rejected override is carried on the client and returned from the request path, so the CLI fails with a clear error rather than falling back to the real API. `requireAuth` became `preflight` since it now covers both the endpoint and the credentials; both call sites updated.

## Tests

`api/` and `config/` had no unit tests, which is a large part of why these went unnoticed. Added:

- `api/client_test.go` — 10 table cases over `resolveBaseURL` (default, https, trailing-slash trim, loopback v4/v6/localhost, plain-http remote, non-loopback IP, bare hostname, non-http scheme), plus that an invalid override surfaces as a request error rather than a silent fallback, plus credential checking.
- `config/config_test.go` — asserts `0600` on a fresh save and on re-saving over a seeded `0644` file. Both skip on Windows, where Unix modes aren't meaningful.

## Verification

`go build ./...`, `go vet ./...`, `go vet -tags=e2e ./tests/...`, `go test ./...`, `gofmt`, `bash -n install.sh`, `go mod tidy` (no change) — all clean. Full suite also run on Linux, where the two permission tests execute rather than skip; all pass.

`install.sh` exercised end-to-end against the live `cli/latest/` artifacts:

| Scenario | Result |
| --- | --- |
| Genuine 1.0.9 linux tarball | `Checksum verified (v1.0.9).`, installs |
| Tampered archive, real checksums | mismatch reported, exit 1, nothing installed |
| `version` marker disagreeing with published checksums | refuses as unverified, exit 1 |

CLI behaviour, built binary:

| Command | Result |
| --- | --- |
| `RAZORPAY_BASE_URL=http://evil.example.com … payments list` | rejected, no request sent, exit 1 |
| `RAZORPAY_BASE_URL=api.evil.example.com … refunds create` | rejected (no scheme/host), exit 1 |
| `RAZORPAY_BASE_URL=http://127.0.0.1:8791/ … payments list` | warns on stderr, request sent to the local server, slash trimmed |
| no override | unchanged — reaches api.razorpay.com |
| `configure` → `payments list` | round-trips; credentials written and read back |

## Note on the third scenario above

The installer's checksum lookup depends on `latest/version` agreeing with the artifacts under `latest/`. #28 describes a path where those can diverge. That is not a regression introduced here — before this change an inconsistent channel installed an unverified binary silently; now it fails loudly, which is the behaviour you want while #28 is outstanding.
