### PR TITLE
fix: pin Homebrew and Scoop manifests to immutable release URLs and verify before publishing

### DIFF
--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -67,7 +67,12 @@ snapshot:
   version_template: "{{ .Version }}-next"
 
 release:
-  disable: true
+  # Attach archives and checksums to the GitHub release for the tag. These
+  # URLs are immutable, which is what the Homebrew formula and Scoop manifest
+  # pin their SHA-256 against -- the cli/latest/ prefix is overwritten on every
+  # release and cannot be pinned. mac, linux and windows each run GoReleaser
+  # separately against the same tag, so append rather than replace.
+  mode: append
 
 blobs:
   - provider: s3

--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -67,7 +67,12 @@ snapshot:
   version_template: "{{ .Version }}-next"
 
 release:
-  disable: true
+  # Attach archives and checksums to the GitHub release for the tag. These
+  # URLs are immutable, which is what the Homebrew formula and Scoop manifest
+  # pin their SHA-256 against -- the cli/latest/ prefix is overwritten on every
+  # release and cannot be pinned. mac, linux and windows each run GoReleaser
+  # separately against the same tag, so append rather than replace.
+  mode: append
 
 blobs:
   - provider: s3

--- a/.goreleaser/windows.yml
+++ b/.goreleaser/windows.yml
@@ -70,7 +70,12 @@ snapshot:
   version_template: "{{ .Version }}-next"
 
 release:
-  disable: true
+  # Attach archives and checksums to the GitHub release for the tag. These
+  # URLs are immutable, which is what the Homebrew formula and Scoop manifest
+  # pin their SHA-256 against -- the cli/latest/ prefix is overwritten on every
+  # release and cannot be pinned. mac, linux and windows each run GoReleaser
+  # separately against the same tag, so append rather than replace.
+  mode: append
 
 blobs:
   - provider: s3

--- a/scripts/update-package-managers.sh
+++ b/scripts/update-package-managers.sh
@@ -17,6 +17,13 @@ set -euo pipefail
 # Config
 # ---------------------------------------------------------------------------
 BASE_URL="https://razorpay.com/cli"
+
+# Artifacts are pinned by SHA-256 in both manifests, so they must come from an
+# immutable URL. BASE_URL/latest/ is overwritten on every release, which would
+# invalidate the pinned hash the moment the next version ships; GitHub release
+# assets are per-tag and never change.
+RELEASE_BASE="https://github.com/razorpay/razorpay-cli/releases/download"
+
 HOMEBREW_REPO="git@github.com:razorpay/homebrew-razorpay-cli.git"
 SCOOP_REPO="git@github.com:razorpay/scoop-razorpay-cli.git"
 
@@ -45,27 +52,88 @@ echo "==> Updating package managers for version ${VERSION_NUM}"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "${TMPDIR}"' EXIT
 
-echo "==> Downloading checksums..."
-curl -fsSL "${BASE_URL}/latest/razorpay-mac-checksums.txt" -o "${TMPDIR}/mac-checksums.txt"
-curl -fsSL "${BASE_URL}/latest/razorpay-windows-checksums.txt" -o "${TMPDIR}/windows-checksums.txt"
+# Read the checksums for the tag being published rather than from latest/. The
+# version is resolved from latest/version but the hashes must describe *that*
+# version, and the two prefixes can drift apart during a partial promotion.
+echo "==> Downloading checksums for v${VERSION_NUM}..."
+curl -fsSL "${RELEASE_BASE}/v${VERSION_NUM}/razorpay-mac-checksums.txt" -o "${TMPDIR}/mac-checksums.txt"
+curl -fsSL "${RELEASE_BASE}/v${VERSION_NUM}/razorpay-windows-checksums.txt" -o "${TMPDIR}/windows-checksums.txt"
 
 # ---------------------------------------------------------------------------
 # Extract SHA256 hashes
 # ---------------------------------------------------------------------------
+# Match the whole filename. A substring match would silently return two hashes
+# on separate lines if a future archive name ever contained another as a suffix.
 get_sha() {
-  local file="$1" checksums="$2"
-  grep "${file}" "${checksums}" | awk '{print $1}'
+  local file="$1" checksums="$2" sha
+  sha=$(awk -v name="${file}" '$2 == name { print $1 }' "${checksums}")
+  if [[ -z "${sha}" ]]; then
+    echo "ERROR: ${checksums##*/} has no entry for ${file}" >&2
+    exit 1
+  fi
+  echo "${sha}"
 }
 
-MAC_ARM64_SHA=$(get_sha "mac-os_arm64.tar.gz" "${TMPDIR}/mac-checksums.txt")
-MAC_AMD64_SHA=$(get_sha "mac-os_x86_64.tar.gz" "${TMPDIR}/mac-checksums.txt")
-WIN_AMD64_SHA=$(get_sha "windows_x86_64.zip" "${TMPDIR}/windows-checksums.txt")
-WIN_I386_SHA=$(get_sha "windows_i386.zip" "${TMPDIR}/windows-checksums.txt")
+MAC_ARM64_FILE="razorpay_${VERSION_NUM}_mac-os_arm64.tar.gz"
+MAC_AMD64_FILE="razorpay_${VERSION_NUM}_mac-os_x86_64.tar.gz"
+WIN_AMD64_FILE="razorpay_${VERSION_NUM}_windows_x86_64.zip"
+WIN_I386_FILE="razorpay_${VERSION_NUM}_windows_i386.zip"
+
+MAC_ARM64_SHA=$(get_sha "${MAC_ARM64_FILE}" "${TMPDIR}/mac-checksums.txt")
+MAC_AMD64_SHA=$(get_sha "${MAC_AMD64_FILE}" "${TMPDIR}/mac-checksums.txt")
+WIN_AMD64_SHA=$(get_sha "${WIN_AMD64_FILE}" "${TMPDIR}/windows-checksums.txt")
+WIN_I386_SHA=$(get_sha "${WIN_I386_FILE}" "${TMPDIR}/windows-checksums.txt")
 
 echo "  mac arm64:     ${MAC_ARM64_SHA}"
 echo "  mac x86_64:    ${MAC_AMD64_SHA}"
 echo "  win x86_64:    ${WIN_AMD64_SHA}"
 echo "  win i386:      ${WIN_I386_SHA}"
+
+# ---------------------------------------------------------------------------
+# Verify every URL that is about to be pinned
+#
+# The manifests pin a hash to a URL. If the two ever disagree, `brew install`
+# and `scoop install` fail outright for everyone, so confirm here -- before a
+# PR is opened -- that each URL resolves and serves exactly the bytes whose
+# hash is going into the manifest.
+# ---------------------------------------------------------------------------
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  else
+    echo "ERROR: neither sha256sum nor shasum is available." >&2
+    exit 1
+  fi
+}
+
+verify_pinned_url() {
+  local url="$1" expected="$2" out actual
+  out="${TMPDIR}/$(basename "${url}")"
+
+  if ! curl -fsSL "${url}" -o "${out}"; then
+    echo "ERROR: ${url} did not resolve." >&2
+    echo "       Release assets are published by .goreleaser/*.yml; check the tag was built." >&2
+    exit 1
+  fi
+
+  actual=$(sha256_of "${out}")
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "ERROR: ${url}" >&2
+    echo "       expected ${expected}" >&2
+    echo "       actual   ${actual}" >&2
+    echo "       Refusing to generate a manifest that cannot install." >&2
+    exit 1
+  fi
+  echo "  ok  $(basename "${url}")"
+}
+
+echo "==> Verifying pinned URLs..."
+verify_pinned_url "${RELEASE_BASE}/v${VERSION_NUM}/${MAC_ARM64_FILE}" "${MAC_ARM64_SHA}"
+verify_pinned_url "${RELEASE_BASE}/v${VERSION_NUM}/${MAC_AMD64_FILE}" "${MAC_AMD64_SHA}"
+verify_pinned_url "${RELEASE_BASE}/v${VERSION_NUM}/${WIN_AMD64_FILE}" "${WIN_AMD64_SHA}"
+verify_pinned_url "${RELEASE_BASE}/v${VERSION_NUM}/${WIN_I386_FILE}" "${WIN_I386_SHA}"
 
 # ---------------------------------------------------------------------------
 # Generate Homebrew formula
@@ -88,10 +156,10 @@ class Razorpay < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "${BASE_URL}/latest/razorpay_mac-os_arm64.tar.gz"
+      url "${RELEASE_BASE}/v${VERSION_NUM}/${MAC_ARM64_FILE}"
       sha256 "${MAC_ARM64_SHA}"
     else
-      url "${BASE_URL}/latest/razorpay_mac-os_x86_64.tar.gz"
+      url "${RELEASE_BASE}/v${VERSION_NUM}/${MAC_AMD64_FILE}"
       sha256 "${MAC_AMD64_SHA}"
     end
   end
@@ -130,11 +198,11 @@ cat > "${SCOOP_DIR}/razorpay.json" <<JSON
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "${BASE_URL}/latest/razorpay_windows_x86_64.zip",
+      "url": "${RELEASE_BASE}/v${VERSION_NUM}/${WIN_AMD64_FILE}",
       "hash": "${WIN_AMD64_SHA}"
     },
     "32bit": {
-      "url": "${BASE_URL}/latest/razorpay_windows_i386.zip",
+      "url": "${RELEASE_BASE}/v${VERSION_NUM}/${WIN_I386_FILE}",
       "hash": "${WIN_I386_SHA}"
     }
   },
@@ -146,11 +214,14 @@ cat > "${SCOOP_DIR}/razorpay.json" <<JSON
   "autoupdate": {
     "architecture": {
       "64bit": {
-        "url": "${BASE_URL}/latest/razorpay_windows_x86_64.zip"
+        "url": "${RELEASE_BASE}/v\$version/razorpay_\$version_windows_x86_64.zip"
       },
       "32bit": {
-        "url": "${BASE_URL}/latest/razorpay_windows_i386.zip"
+        "url": "${RELEASE_BASE}/v\$version/razorpay_\$version_windows_i386.zip"
       }
+    },
+    "hash": {
+      "url": "${RELEASE_BASE}/v\$version/razorpay-windows-checksums.txt"
     }
   }
 }


### PR DESCRIPTION
Fixes #27.

The Homebrew formula and Scoop manifest pinned a `sha256` to `cli/latest/…`, which `.github/workflows/release.yml` overwrites in place on every release. Publishing a new version silently invalidates the hash in the already-merged manifests, and `brew install` / `scoop install` then fail for everyone until a PR is merged in a separate repo.

A hash can only be pinned to a URL that never changes, so this PR provides one and then points the manifests at it.

## 1. Release artifacts are attached to the GitHub tag (`.goreleaser/*.yml`)

All three configs had `release: disable: true`, so `v1.0.8` and `v1.0.9` exist as GitHub releases with **zero assets** — and `cli/<version>/` is not served publicly (`https://razorpay.com/cli/1.0.9/…` returns 404), so there was no immutable URL anywhere to point at.

Changed to `release: mode: append`. Per-tag release asset URLs never change, which is what the manifests need. `append` rather than the default because mac, linux and windows each run GoReleaser separately against the same tag and must not clobber each other's assets.

The S3 `blobs` upload is unchanged — `cli/latest/` and `cli/<version>/` keep working exactly as before, so `install.sh` and the manual-download docs are unaffected. This only adds a second, immutable location.

## 2. Manifests pin the immutable URL (`scripts/update-package-managers.sh`)

Homebrew `url` and Scoop `architecture.*.url` now point at `…/releases/download/v<version>/razorpay_<version>_<os>_<arch>.<ext>`.

`checkver.url` deliberately stays on `cli/latest/version` — that one is *supposed* to be mutable; it is how Scoop discovers that a new version exists.

Two related corrections while in here:

- **Checksums are read from the tag, not from `latest/`.** The version was resolved from `latest/version` while the hashes came from `latest/*checksums.txt`; those two prefixes can drift apart (see #28), which would produce a manifest labelled with one version carrying another version's hashes. Both now come from the same immutable place.
- **Scoop `autoupdate` gained a `hash.url`.** It previously listed URLs with no hash source, so it had no way to learn the hash for a new version. It now points at the checksums file for the tag.

## 3. The script can no longer emit a manifest that cannot install

`get_sha` used `grep "<substring>"`, which would return two hashes on separate lines if one archive name were ever a suffix of another. Now an exact `awk` field match, and a missing entry is a hard error instead of an empty `sha256 ""`.

Added a preflight that, before generating anything, downloads each URL about to be pinned and confirms it serves exactly the bytes whose hash is going into the manifest. A 404 or a mismatch aborts the script. This is the safety net that matters: the failure in #27 is invisible at generation time and only surfaces later on users' machines, and a reviewer cannot catch it by eye — it is four hex strings.

## Verification

Ran the generation logic end-to-end against fixtures with a stubbed `curl`:

| Case | Result |
| --- | --- |
| All four artifacts match their published hashes | `ok` ×4, both manifests generated, exit 0 |
| An artifact's bytes don't match the published hash | reports expected vs actual, refuses, exit 1 |
| A release asset is missing (tag not built) | reports the URL didn't resolve, refuses, exit 1 |
| Checksum file has no entry for the version | reports the missing entry, refuses, exit 1 |

Confirmed on the generated output that the Homebrew `url`/`sha256` pairs and Scoop `url`/`hash` pairs carry versioned URLs, that `checkver` still points at `latest/version`, and that the Scoop `$version` placeholders survive shell expansion as literals. The generated `razorpay.json` parses as valid JSON.

`bash -n` on the script, YAML parse on all three GoReleaser configs, and `go build ./...` / `go vet ./...` / `go test ./...` all pass. No Go files are touched.

## What I could not verify, and one thing to decide

- **The release pipeline itself.** I can't run it. The `mode: append` behaviour with three parallel GoReleaser invocations against one tag is the part worth watching on the first release after merge — in particular whether the three jobs racing to create the release for a brand-new tag is handled cleanly. If it isn't, the alternative is to have one job create the release and the other two append.
- **The formula is not Ruby-syntax-checked**, as I have no Ruby locally. Only the two `url` lines changed within an otherwise untouched template.
- **If you'd rather not publish GitHub release assets**, the equivalent fix is to route `cli/<version>/` through the CDN and point `RELEASE_BASE` at it instead — the objects already exist and are publicly readable directly from S3 today, it's only the `razorpay.com` route that 404s. That's a one-line change to `RELEASE_BASE` plus an infra change, and the preflight added here would guard it either way. Happy to switch if that's preferred.

Related: #28 covers the promotion-ordering defect that can make `latest/version` and `latest/*checksums.txt` disagree.
